### PR TITLE
Wrap month and year divs to avoid overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Upcoming Release
 
+- [BUGFIX] Wrap month and year options so they fit within the cointaining div
 - [DOC] Add a changelog
 
 ### 0.0.5 (October 25, 2015)

--- a/app/assets/stylesheets/datetime_picker.scss
+++ b/app/assets/stylesheets/datetime_picker.scss
@@ -289,6 +289,7 @@
 .bootstrap-datetimepicker-widget table td {
   height: 54px;
   line-height: 54px;
+  white-space: normal;
   width: 54px;
 }
 .bootstrap-datetimepicker-widget table td.cw {


### PR DESCRIPTION
## Problem:

A missing CSS rule was causing the month and year selectors
to overflow their container div.

![Before](https://cloud.githubusercontent.com/assets/15331482/11431522/87ad6c9c-945f-11e5-8331-888c1738a342.png)
## Solution:

Add `white-space: normal` to `td`s and `th`s in the datetime picker
element. This fixes the wrapping.

![After](https://cloud.githubusercontent.com/assets/15331482/11431521/87acdb2e-945f-11e5-98d1-298449e613d4.png)

The solution was originally suggested by @33volcanoes in https://github.com/thoughtbot/administrate/pull/275.
