### PR TITLE
Fix datepicker styles

### DIFF
--- a/app/assets/stylesheets/datetime_picker/_dropdowns.scss
+++ b/app/assets/stylesheets/datetime_picker/_dropdowns.scss
@@ -8,7 +8,6 @@
   top: 100%;
   left: 0;
   z-index: $zindex-dropdown;
-  display: none; // none by default, but block on "open" of the menu
   float: left;
   min-width: 160px;
   padding: 5px 0;

--- a/app/assets/stylesheets/datetime_picker/_tables.scss
+++ b/app/assets/stylesheets/datetime_picker/_tables.scss
@@ -12,6 +12,7 @@
       > th,
       > td {
         padding: $table-condensed-cell-padding;
+        border: none;
       }
     }
   }


### PR DESCRIPTION
While investigating on https://github.com/thoughtbot/administrate/issues/661, I realized that the HTML for the picker was inserted in the page, but a `display: none` prevented it from displaying at all.

I also explicitly set no borders on picker table cells to prevent other stylesheets (e.g. Administrate’s) from inadvertently adding them.
